### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(sfl
+	LANGUAGES
+		CXX
+)
+
+add_library(sfl INTERFACE)
+add_library(sfl::sfl ALIAS sfl)
+
+target_include_directories(sfl INTERFACE
+	include
+)
+
+set_property(TARGET sfl PROPERTY CXX_STANDARD 11)


### PR DESCRIPTION
This adds very basic CMake support to allow this library to be used with git submodule or CMake FetchContent. The target just has to add `sfl::sfl` to the link libraries to get the include path added.