### PR TITLE
Declare iterator_concept for C++20(+), enables the use of std::ranges

### DIFF
--- a/include/sfl/private.hpp
+++ b/include/sfl/private.hpp
@@ -271,6 +271,9 @@ public:
     using pointer           = typename std::iterator_traits<Iterator>::pointer;
     using reference         = typename std::iterator_traits<Iterator>::reference;
     using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
+#if __cplusplus >= 202004 || (defined(_MSVC_LANG) && _MSVC_LANG >= 202004)
+    using iterator_concept  = std::contiguous_iterator_tag;
+#endif
 
 private:
 

--- a/include/sfl/private.hpp
+++ b/include/sfl/private.hpp
@@ -39,13 +39,19 @@
 
 #define SFL_ASSERT(x) assert(x)
 
-#if __cplusplus >= 201402L
+#if defined(_MSC_VER) && defined(_MSVC_LANG)
+    #define SFL_CXX_VERSION _MSVC_LANG
+#else
+    #define SFL_CXX_VERSION __cplusplus
+#endif
+
+#if SFL_CXX_VERSION >= 201402L
     #define SFL_CONSTEXPR_14 constexpr
 #else
     #define SFL_CONSTEXPR_14
 #endif
 
-#if __cplusplus >= 201703L
+#if SFL_CXX_VERSION >= 201703L
     #define SFL_NODISCARD [[nodiscard]]
 #else
     #define SFL_NODISCARD
@@ -271,7 +277,7 @@ public:
     using pointer           = typename std::iterator_traits<Iterator>::pointer;
     using reference         = typename std::iterator_traits<Iterator>::reference;
     using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
-#if __cplusplus >= 202004 || (defined(_MSVC_LANG) && _MSVC_LANG >= 202004)
+#if SFL_CXX_VERSION >= 202004
     using iterator_concept  = std::contiguous_iterator_tag;
 #endif
 


### PR DESCRIPTION
Without this its a bit iffy to work with std::span, with the iterator_concept declared we can pass the container to the constructor and it will just work.
```cpp
static_assert(std::random_access_iterator<sfl::small_vector<uint8_t, 16>::iterator>); 
static_assert(std::contiguous_iterator<sfl::small_vector<uint8_t, 16>::iterator>); 
static_assert(std::ranges::contiguous_range<sfl::small_vector<uint8_t, 16>>); 
static_assert(std::ranges::contiguous_range<sfl::vector<uint8_t>>);
```
Above code will now successfully compile with C++20 enabled.