### PR TITLE
Add debugger visualization support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ target_include_directories(sfl INTERFACE
 
 set_property(TARGET sfl PROPERTY CXX_STANDARD 11)
 
+set(SFL_NATVIS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/sfl.natvis")
+
+target_link_options(sfl INTERFACE
+    $<$<CXX_COMPILER_ID:MSVC>:/natvis:${SFL_NATVIS_FILE}>
+)
+
 install(
 	DIRECTORY
 		include/sfl

--- a/sfl.natvis
+++ b/sfl.natvis
@@ -323,4 +323,216 @@
         </Expand>
     </Type>
 
+    <Type Name="sfl::map&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::map&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>(sfl::map&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>(sfl::map&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::multimap&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::multimap&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>(sfl::multimap&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>(sfl::multimap&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::set&lt;*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::set&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>(sfl::set&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>(sfl::set&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::multiset&lt;*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::multiset&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>(sfl::multiset&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>(sfl::multiset&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_map&lt;*,*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::small_map&lt;$T1,$T2,$T3,$T4,$T5&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::small_map&lt;$T1,$T2,$T3,$T4,$T5&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::small_map&lt;$T1,$T2,$T3,$T4,$T5&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_multimap&lt;*,*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::small_multimap&lt;$T1,$T2,$T3,$T4,$T5&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::small_multimap&lt;$T1,$T2,$T3,$T4,$T5&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::small_multimap&lt;$T1,$T2,$T3,$T4,$T5&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_set&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::small_set&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::small_set&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::small_set&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_multiset&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <TreeItems>
+                <Size>size()</Size>
+                <HeadPointer>
+                    (sfl::small_multiset&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::small_multiset&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::small_multiset&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_map&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::static_map&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::static_map&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::static_map&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_multimap&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::static_multimap&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::static_multimap&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::static_multimap&lt;$T1,$T2,$T3,$T4&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_set&lt;*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <TreeItems>
+                <Size>tree_.data_.size_</Size>
+                <HeadPointer>
+                    (sfl::static_set&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::static_set&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::static_set&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_multiset&lt;*,*,*&gt;">
+        <Intrinsic Name="size" Expression="tree_.data_.size_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size()</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <TreeItems>
+                <Size>size()</Size>
+                <HeadPointer>
+                    (sfl::static_multiset&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)tree_.data_.header_.left_</HeadPointer>
+                <LeftPointer>
+                    (sfl::static_multiset&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)left_</LeftPointer>
+                <RightPointer>
+                    (sfl::static_multiset&lt;$T1,$T2,$T3&gt;::tree_type::node_pointer)right_</RightPointer>
+                <ValueNode>value_</ValueNode>
+            </TreeItems>
+        </Expand>
+    </Type>
+
 </AutoVisualizer>

--- a/sfl.natvis
+++ b/sfl.natvis
@@ -63,11 +63,14 @@
         <DisplayString>{{ size={((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
             + (data_.last_.local_ - *(data_.last_.segment_))} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">((data_.last_.segment_ - data_.first_.segment_)
-                * segment_capacity) + (data_.last_.local_ - *(data_.last_.segment_))</Item>
-            <Item Name="[capacity]" ExcludeView="simple">((data_.eos_.segment_ -
-                data_.first_.segment_) * segment_capacity) + (data_.eos_.local_ -
-                *(data_.eos_.segment_))</Item>
+            <Item Name="[size]" ExcludeView="simple">(data_.last_.segment_ - data_.first_.segment_)
+                * segment_capacity +
+                (data_.last_.local_ - *data_.last_.segment_) -
+                (data_.first_.local_ - *data_.first_.segment_)</Item>
+            <Item Name="[capacity]" ExcludeView="simple">(data_.eos_.segment_ -
+                data_.first_.segment_) * segment_capacity +
+                (data_.eos_.local_ - *data_.eos_.segment_) -
+                (data_.first_.local_ - *data_.first_.segment_)</Item>
             <Synthetic Name="[segments]" Optional="true">
                 <DisplayString>({data_.table_last_ - data_.table_first_})</DisplayString>
                 <Expand>
@@ -78,8 +81,10 @@
                 </Expand>
             </Synthetic>
             <IndexListItems>
-                <Size>((data_.last_.segment_ - data_.first_.segment_) * segment_capacity) +
-                    (data_.last_.local_ - *(data_.last_.segment_))</Size>
+                <Size>(data_.last_.segment_ - data_.first_.segment_)
+                    * segment_capacity +
+                    (data_.last_.local_ - *data_.last_.segment_) -
+                    (data_.first_.local_ - *data_.first_.segment_)</Size>
                 <ValueNode>*(*(data_.table_first_ + ($i / segment_capacity)) + ($i %
                     segment_capacity))</ValueNode>
             </IndexListItems>
@@ -90,15 +95,19 @@
         <DisplayString>{{ size={((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
             + (data_.last_.local_ - *(data_.last_.segment_))} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">((data_.last_.segment_ - data_.first_.segment_)
-                * segment_capacity) + (data_.last_.local_ - *(data_.last_.segment_))</Item>
-            <Item Name="[capacity]" ExcludeView="simple">((data_.eos_.segment_ -
-                data_.bos_.segment_) * segment_capacity) + (data_.eos_.local_ -
-                *(data_.eos_.segment_))</Item>
+            <Item Name="[size]" ExcludeView="simple">(data_.last_.segment_ - data_.first_.segment_)
+                * segment_capacity +
+                (data_.last_.local_ - *data_.last_.segment_) -
+                (data_.first_.local_ - *data_.first_.segment_)</Item>
+            <Item Name="[capacity]" ExcludeView="simple">(data_.eos_.segment_ - data_.bos_.segment_)
+                * segment_capacity +
+                (data_.eos_.local_ - *data_.eos_.segment_) -
+                (data_.bos_.local_ - *data_.bos_.segment_)</Item>
             <Item Name="[segments]" ExcludeView="simple">data_.table_last_ - data_.table_first_</Item>
             <IndexListItems>
-                <Size>((data_.last_.segment_ - data_.first_.segment_) * segment_capacity) +
-                    (data_.last_.local_ - *(data_.last_.segment_))</Size>
+                <Size>(data_.last_.segment_ - data_.first_.segment_) * segment_capacity +
+                    (data_.last_.local_ - *data_.last_.segment_) -
+                    (data_.first_.local_ - *data_.first_.segment_)</Size>
                 <ValueNode>
                     *(*(data_.table_first_ + (($i + (data_.first_.local_ -
                     *(data_.first_.segment_))) / segment_capacity)) + (($i + (data_.first_.local_ -

--- a/sfl.natvis
+++ b/sfl.natvis
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="sfl::compact_vector&lt;*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::vector&lt;*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::devector&lt;*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_vector&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_vector&lt;*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::segmented_vector&lt;*,*,*&gt;">
+        <DisplayString>{{ size={((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
+            + (data_.last_.local_ - *(data_.last_.segment_))} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">((data_.last_.segment_ - data_.first_.segment_)
+                * segment_capacity) + (data_.last_.local_ - *(data_.last_.segment_))</Item>
+            <Item Name="[capacity]" ExcludeView="simple">((data_.eos_.segment_ -
+                data_.first_.segment_) * segment_capacity) + (data_.eos_.local_ -
+                *(data_.eos_.segment_))</Item>
+            <Synthetic Name="[segments]" Optional="true">
+                <DisplayString>({data_.table_last_ - data_.table_first_})</DisplayString>
+                <Expand>
+                    <IndexListItems>
+                        <Size>data_.table_last_ - data_.table_first_</Size>
+                        <ValueNode>*(data_.table_first_ + $i)</ValueNode>
+                    </IndexListItems>
+                </Expand>
+            </Synthetic>
+            <IndexListItems>
+                <Size>((data_.last_.segment_ - data_.first_.segment_) * segment_capacity) +
+                    (data_.last_.local_ - *(data_.last_.segment_))</Size>
+                <ValueNode>*(*(data_.table_first_ + ($i / segment_capacity)) + ($i %
+                    segment_capacity))</ValueNode>
+            </IndexListItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::segmented_devector&lt;*,*,*&gt;">
+        <DisplayString>{{ size={((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
+            + (data_.last_.local_ - *(data_.last_.segment_))} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">((data_.last_.segment_ - data_.first_.segment_)
+                * segment_capacity) + (data_.last_.local_ - *(data_.last_.segment_))</Item>
+            <Item Name="[capacity]" ExcludeView="simple">((data_.eos_.segment_ -
+                data_.bos_.segment_) * segment_capacity) + (data_.eos_.local_ -
+                *(data_.eos_.segment_))</Item>
+            <Item Name="[segments]" ExcludeView="simple">data_.table_last_ - data_.table_first_</Item>
+            <IndexListItems>
+                <Size>((data_.last_.segment_ - data_.first_.segment_) * segment_capacity) +
+                    (data_.last_.local_ - *(data_.last_.segment_))</Size>
+                <ValueNode>
+                    *(*(data_.table_first_ + (($i + (data_.first_.local_ -
+                    *(data_.first_.segment_))) / segment_capacity)) + (($i + (data_.first_.local_ -
+                    *(data_.first_.segment_))) % segment_capacity)) </ValueNode>
+            </IndexListItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_flat_map&lt;*,*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_flat_multimap&lt;*,*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_flat_multiset&lt;*,*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_flat_set&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_flat_map&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_flat_set&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_flat_multimap&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_flat_multiset&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_unordered_flat_map&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_unordered_flat_multimap&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_unordered_flat_multiset&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::static_unordered_flat_set&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_unordered_flat_map&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_unordered_flat_multimap&lt;*,*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_unordered_flat_multiset&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="sfl::small_unordered_flat_set&lt;*,*,*&gt;">
+        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Expand>
+            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
+            <ArrayItems>
+                <Size>data_.last_ - data_.first_</Size>
+                <ValuePointer>data_.first_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+</AutoVisualizer>

--- a/sfl.natvis
+++ b/sfl.natvis
@@ -1,72 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
     <Type Name="sfl::compact_vector&lt;*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
+            <Item Name="[capacity]" ExcludeView="simple">size()</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::vector&lt;*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::devector&lt;*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_vector&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_vector&lt;*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::segmented_vector&lt;*,*,*&gt;">
-        <DisplayString>{{ size={((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
-            + (data_.last_.local_ - *(data_.last_.segment_))} }}</DisplayString>
+        <Intrinsic Name="size"
+            Expression="((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
+            + (data_.last_.local_ - *(data_.last_.segment_))" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">(data_.last_.segment_ - data_.first_.segment_)
-                * segment_capacity +
-                (data_.last_.local_ - *data_.last_.segment_) -
-                (data_.first_.local_ - *data_.first_.segment_)</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">(data_.eos_.segment_ -
                 data_.first_.segment_) * segment_capacity +
                 (data_.eos_.local_ - *data_.eos_.segment_) -
@@ -81,10 +86,7 @@
                 </Expand>
             </Synthetic>
             <IndexListItems>
-                <Size>(data_.last_.segment_ - data_.first_.segment_)
-                    * segment_capacity +
-                    (data_.last_.local_ - *data_.last_.segment_) -
-                    (data_.first_.local_ - *data_.first_.segment_)</Size>
+                <Size>size()</Size>
                 <ValueNode>*(*(data_.table_first_ + ($i / segment_capacity)) + ($i %
                     segment_capacity))</ValueNode>
             </IndexListItems>
@@ -92,217 +94,229 @@
     </Type>
 
     <Type Name="sfl::segmented_devector&lt;*,*,*&gt;">
-        <DisplayString>{{ size={((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
-            + (data_.last_.local_ - *(data_.last_.segment_))} }}</DisplayString>
+        <Intrinsic Name="size"
+            Expression="((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
+            + (data_.last_.local_ - *(data_.last_.segment_))" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">(data_.last_.segment_ - data_.first_.segment_)
-                * segment_capacity +
-                (data_.last_.local_ - *data_.last_.segment_) -
-                (data_.first_.local_ - *data_.first_.segment_)</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">(data_.eos_.segment_ - data_.bos_.segment_)
                 * segment_capacity +
                 (data_.eos_.local_ - *data_.eos_.segment_) -
                 (data_.bos_.local_ - *data_.bos_.segment_)</Item>
             <Item Name="[segments]" ExcludeView="simple">data_.table_last_ - data_.table_first_</Item>
             <IndexListItems>
-                <Size>(data_.last_.segment_ - data_.first_.segment_) * segment_capacity +
-                    (data_.last_.local_ - *data_.last_.segment_) -
-                    (data_.first_.local_ - *data_.first_.segment_)</Size>
-                <ValueNode>
-                    *(*(data_.table_first_ + (($i + (data_.first_.local_ -
+                <Size>size()</Size>
+                <ValueNode>*(*(data_.table_first_ + (($i + (data_.first_.local_ -
                     *(data_.first_.segment_))) / segment_capacity)) + (($i + (data_.first_.local_ -
-                    *(data_.first_.segment_))) % segment_capacity)) </ValueNode>
+                    *(data_.first_.segment_))) % segment_capacity))</ValueNode>
             </IndexListItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_flat_map&lt;*,*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_flat_multimap&lt;*,*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_flat_multiset&lt;*,*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_flat_set&lt;*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_flat_map&lt;*,*,*,*&gt;">
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
         <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_flat_set&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_flat_multimap&lt;*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_flat_multiset&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_unordered_flat_map&lt;*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_unordered_flat_multimap&lt;*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_unordered_flat_multiset&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::static_unordered_flat_set&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_unordered_flat_map&lt;*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_unordered_flat_multimap&lt;*,*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_unordered_flat_multiset&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>
     </Type>
 
     <Type Name="sfl::small_unordered_flat_set&lt;*,*,*&gt;">
-        <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+        <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+        <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
-            <Item Name="[size]" ExcludeView="simple">data_.last_ - data_.first_</Item>
+            <Item Name="[size]" ExcludeView="simple">size()</Item>
             <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
             <ArrayItems>
-                <Size>data_.last_ - data_.first_</Size>
+                <Size>size()</Size>
                 <ValuePointer>data_.first_</ValuePointer>
             </ArrayItems>
         </Expand>

--- a/sfl.natvis
+++ b/sfl.natvis
@@ -95,8 +95,9 @@
 
     <Type Name="sfl::segmented_devector&lt;*,*,*&gt;">
         <Intrinsic Name="size"
-            Expression="((data_.last_.segment_ - data_.first_.segment_) * segment_capacity)
-            + (data_.last_.local_ - *(data_.last_.segment_))" />
+            Expression="((data_.last_.segment_ - data_.first_.segment_) * segment_capacity) + 
+                (data_.last_.local_ - *data_.last_.segment_) - 
+                (data_.first_.local_ - *data_.first_.segment_)" />
         <DisplayString>{{ size={size()} }}</DisplayString>
         <Expand>
             <Item Name="[size]" ExcludeView="simple">size()</Item>
@@ -107,9 +108,9 @@
             <Item Name="[segments]" ExcludeView="simple">data_.table_last_ - data_.table_first_</Item>
             <IndexListItems>
                 <Size>size()</Size>
-                <ValueNode>*(*(data_.table_first_ + (($i + (data_.first_.local_ -
-                    *(data_.first_.segment_))) / segment_capacity)) + (($i + (data_.first_.local_ -
-                    *(data_.first_.segment_))) % segment_capacity))</ValueNode>
+                <ValueNode>*(*(data_.first_.segment_ + ($i + data_.first_.local_ -
+                    *data_.first_.segment_) / segment_capacity)
+                    + (($i + data_.first_.local_ - *data_.first_.segment_) % segment_capacity))</ValueNode>
             </IndexListItems>
         </Expand>
     </Type>
@@ -321,4 +322,5 @@
             </ArrayItems>
         </Expand>
     </Type>
+
 </AutoVisualizer>


### PR DESCRIPTION
This adds a .natvis file to the project and adds a linker option for MSVC to direct the linker to embed the file into the .pdb which turns following:
![devenv_2025-03-04_01-50-421741045842](https://github.com/user-attachments/assets/526613fc-0f2b-4adc-b185-ad988135c4b3)
into a much nicer view:
![devenv_2025-03-04_01-49-431741045783](https://github.com/user-attachments/assets/c30ca260-7444-45b0-87bd-21538eb7a6a9)

Which is also the same as to how the standard STL containers are displayed. The natvis for the MSVC STL is also available on GitHub https://github.com/microsoft/STL/blob/main/stl/debugger/STL.natvis, I think most people aren't even aware that this is how the debugger has been showing all the data all this time.

~~I have left the containers out that use the RB tree as it stores the base_node rather than the actual node which makes it very difficult to visualize the data. I'm not sure what the purpose of the base node is and I think it can be probably removed as the tree is always aware of the type and so is the container holding the tree, this would also remove the need of the casts in the iterators, I just briefly looked at it so there might be a reason for doing this.~~ Now complete.

Close #16