### PR TITLE
Mark function as inline to avoid duplicate symbols

### DIFF
--- a/include/sfl/detail/hash_table.hpp
+++ b/include/sfl/detail/hash_table.hpp
@@ -594,7 +594,7 @@ private:
 };
 
 template <>
-std::size_t hash_table_static_pow2_bucket_count_policy<1>::calculate_bucket_index_for_hash(std::size_t hash) const
+inline std::size_t hash_table_static_pow2_bucket_count_policy<1>::calculate_bucket_index_for_hash(std::size_t hash) const
 {
     sfl::dtl::ignore_unused(hash);
     return 0;


### PR DESCRIPTION
If a.cpp and b.cpp include unordered_map or anything that includes the hash table will get linker errors, at least with MSVC.