### PR TITLE
Update natvis to work with the latest changes

### DIFF
--- a/sfl.natvis
+++ b/sfl.natvis
@@ -169,16 +169,16 @@
     <AlternativeType Name="sfl::small_flat_multimap&lt;*,*,*,*,*&gt;" />
     <AlternativeType Name="sfl::small_unordered_linear_map&lt;*,*,*,*&gt;" />
     <AlternativeType Name="sfl::small_unordered_linear_multimap&lt;*,*,*,*,*&gt;" />
-    <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+    <Intrinsic Name="size" Expression="impl_.data_.last_ - impl_.data_.first_" />
     <DisplayString>{{ size={size()} }}</DisplayString>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">size()</Item>
-      <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+      <Item Name="[capacity]" ExcludeView="simple">impl_.data_.eos_ - impl_.data_.first_</Item>
       <CustomListItems>
         <Variable Name="i" InitialValue="0" />
         <Size>size()</Size>
         <Loop>
-          <Item Name="[{data_.first_[i].first}]">data_.first_[i].second</Item>
+          <Item Name="[{impl_.data_.first_[i].first}]">impl_.data_.first_[i].second</Item>
           <Exec>i++</Exec>
         </Loop>
       </CustomListItems>
@@ -189,8 +189,8 @@
     <AlternativeType Name="sfl::static_flat_multimap&lt;*,*,*,*&gt;" />
     <AlternativeType Name="sfl::static_unordered_linear_map&lt;*,*,*,*&gt;" />
     <AlternativeType Name="sfl::static_unordered_linear_multimap&lt;*,*,*,*&gt;" />
-    <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
-    <DisplayString>{{ size={data_.last_ - data_.first_} }}</DisplayString>
+    <Intrinsic Name="size" Expression="impl_.data_.last_ - impl_.data_.first_" />
+    <DisplayString>{{ size={impl_.data_.last_ - impl_.data_.first_} }}</DisplayString>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">size()</Item>
       <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
@@ -198,7 +198,7 @@
         <Variable Name="i" InitialValue="0" />
         <Size>size()</Size>
         <Loop>
-          <Item Name="[{data_.first_[i].first}]">data_.first_[i].second</Item>
+          <Item Name="[{impl_.data_.first_[i].first}]">impl_.data_.first_[i].second</Item>
           <Exec>i++</Exec>
         </Loop>
       </CustomListItems>
@@ -459,14 +459,14 @@
   <Type Name="sfl::small_flat_set&lt;*,*,*,*&gt;">
     <AlternativeType Name="sfl::small_unordered_linear_set&lt;*,*,*,*&gt;" />
     <AlternativeType Name="sfl::small_unordered_linear_multiset&lt;*,*,*,*&gt;" />
-    <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+    <Intrinsic Name="size" Expression="impl_.data_.last_ - impl_.data_.first_" />
     <DisplayString>{{ size={size()} }}</DisplayString>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">size()</Item>
-      <Item Name="[capacity]" ExcludeView="simple">data_.eos_ - data_.first_</Item>
+      <Item Name="[capacity]" ExcludeView="simple">impl_.data_.eos_ - impl_.data_.first_</Item>
       <ArrayItems>
         <Size>size()</Size>
-        <ValuePointer>data_.first_</ValuePointer>
+        <ValuePointer>impl_.data_.first_</ValuePointer>
       </ArrayItems>
     </Expand>
   </Type>
@@ -475,14 +475,14 @@
     <AlternativeType Name="sfl::static_flat_multiset&lt;*,*,*&gt;" />
     <AlternativeType Name="sfl::static_unordered_linear_multiset&lt;*,*,*&gt;" />
     <AlternativeType Name="sfl::static_unordered_linear_set&lt;*,*,*&gt;" />
-    <Intrinsic Name="size" Expression="data_.last_ - data_.first_" />
+    <Intrinsic Name="size" Expression="impl_.data_.last_ - impl_.data_.first_" />
     <DisplayString>{{ size={size()} }}</DisplayString>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">size()</Item>
       <Item Name="[capacity]" ExcludeView="simple">static_capacity</Item>
       <ArrayItems>
         <Size>size()</Size>
-        <ValuePointer>data_.first_</ValuePointer>
+        <ValuePointer>impl_.data_.first_</ValuePointer>
       </ArrayItems>
     </Expand>
   </Type>


### PR DESCRIPTION
I was unfortunately not able to really improve much other than just get it working again. One of the key issues that prevents deduplication is that natvis does not tell me what type matched and without the correct type we can not properly cast the node values, we could in theory just pretend that everything is just static_set, static_map, etc. for the casts but that feels somewhat icky to not use the actual type definition, also its not that simple to use the fully qualified type of rb_tree as the last template argument seems to be currently the container itsself, so that would be just a giant mess, there is also no way to declare new typedefs within the natvis evaluation context. Natvis can also not execute functions and is limited to reading data only so that also sucks, I think we have to stick with duplication for now or simplify the overall code structure.